### PR TITLE
Fix nil error & subsequent app crash

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -118,7 +118,9 @@ public class GoogleAuth: CAPPlugin {
     @objc
     func signOut(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            self.googleSignIn.signOut();
+            if self.googleSignIn != nil {
+                self.googleSignIn.signOut();
+            }
         }
         call.resolve();
     }


### PR DESCRIPTION
The `signOut` subroutine within `Plugin.swift` sometimes causes an app crash.

This is due to the function invoking the `signOut` method on `self.googleSignIn` when `self.googleSignIn` is `nil`.